### PR TITLE
docs: Add comprehensive documentation for ALaS

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 ALaS is a general-purpose, Turing-complete programming language designed exclusively for AI models to generate, manipulate, and execute. It uses structured JSON representations to enable low-error, high-speed code generation and transformation by LLMs.
 
+**For LLM Users**: Check out our comprehensive [documentation](docs/README.md) designed specifically to help AI systems generate ALaS code effectively. The [LLM Integration Guide](docs/llm-guide.md) provides optimal prompting strategies and common patterns.
+
 ## Features
 
 - **Machine-First Design**: Optimized for AI generation, not human readability
@@ -36,9 +38,26 @@ alas/
 │   ├── modules/           # Example ALaS modules (math_utils, format_utils)
 │   └── plugins/           # Example plugin implementations
 ├── tests/                 # Test suite with optimization and multi-module tests
-└── docs/
-    └── alas_lang_spec.md  # Language specification
+└── docs/                  # Comprehensive documentation
+    ├── README.md          # Documentation overview
+    ├── language-spec.md   # Complete language specification
+    ├── getting-started.md # Quick start guide
+    ├── stdlib-reference.md # Standard library reference
+    ├── plugin-system.md   # Plugin development guide
+    ├── examples.md        # Code examples and patterns
+    ├── llm-guide.md       # LLM integration guide
+    └── troubleshooting.md # Common issues and solutions
 ```
+
+## Documentation
+
+- **[Getting Started Guide](docs/getting-started.md)** - Quick introduction to writing ALaS programs
+- **[Language Specification](docs/language-spec.md)** - Complete language reference
+- **[Standard Library Reference](docs/stdlib-reference.md)** - All built-in functions
+- **[Plugin System Guide](docs/plugin-system.md)** - Extending ALaS
+- **[Examples](docs/examples.md)** - Sample programs and patterns
+- **[LLM Integration Guide](docs/llm-guide.md)** - For AI-assisted development
+- **[Troubleshooting](docs/troubleshooting.md)** - Common issues and solutions
 
 ## Getting Started
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,64 @@
+# ALaS Documentation
+
+Welcome to the ALaS (Artificial Language for Autonomous Systems) documentation. ALaS is a programming language specifically designed for machine generation and manipulation by AI/LLM systems.
+
+## Documentation Overview
+
+- **[Language Specification](language-spec.md)** - Complete ALaS language reference
+- **[Getting Started Guide](getting-started.md)** - Quick introduction to writing ALaS programs
+- **[Standard Library Reference](stdlib-reference.md)** - Built-in functions and modules
+- **[Plugin System](plugin-system.md)** - Extending ALaS with custom functionality
+- **[Examples](examples.md)** - Sample programs and patterns
+- **[LLM Integration Guide](llm-guide.md)** - Best practices for generating ALaS with AI
+
+## Key Features
+
+- **JSON-based syntax** - Machine-readable format optimized for AI generation
+- **Type safety** - Strong typing with inference capabilities
+- **Module system** - Organize code into reusable modules
+- **Standard library** - Rich set of built-in functions
+- **Plugin architecture** - Extend the language with custom functionality
+- **Multiple backends** - Interpreter and LLVM compiler support
+
+## Quick Example
+
+```json
+{
+  "type": "module",
+  "name": "hello",
+  "functions": [
+    {
+      "type": "function",
+      "name": "main",
+      "params": [],
+      "returns": "void",
+      "body": [
+        {
+          "type": "expr",
+          "value": {
+            "type": "builtin",
+            "name": "io.print",
+            "args": [
+              {"type": "literal", "value": "Hello, ALaS!"}
+            ]
+          }
+        }
+      ]
+    }
+  ]
+}
+```
+
+## Getting Help
+
+- Check the [troubleshooting guide](troubleshooting.md) for common issues
+- View [examples](examples.md) for practical code patterns
+- Refer to the [language specification](language-spec.md) for detailed syntax
+
+## For AI/LLM Users
+
+If you're using an AI system to generate ALaS code, see the [LLM Integration Guide](llm-guide.md) for:
+- Optimal prompting strategies
+- Common patterns and idioms
+- Error handling and debugging tips
+- Performance considerations

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -1,0 +1,876 @@
+# ALaS Examples
+
+This document contains various example programs demonstrating ALaS features and common programming patterns.
+
+## Basic Examples
+
+### Hello World
+
+The simplest ALaS program:
+
+```json
+{
+  "type": "module",
+  "name": "hello",
+  "functions": [
+    {
+      "type": "function",
+      "name": "main",
+      "params": [],
+      "returns": "void",
+      "body": [
+        {
+          "type": "expr",
+          "value": {
+            "type": "builtin",
+            "name": "io.print",
+            "args": [{"type": "literal", "value": "Hello, World!"}]
+          }
+        }
+      ]
+    }
+  ]
+}
+```
+
+### Variables and Arithmetic
+
+```json
+{
+  "type": "module",
+  "name": "arithmetic",
+  "functions": [
+    {
+      "type": "function",
+      "name": "main",
+      "params": [],
+      "returns": "int",
+      "body": [
+        {
+          "type": "assign",
+          "target": "a",
+          "value": {"type": "literal", "value": 10}
+        },
+        {
+          "type": "assign",
+          "target": "b",
+          "value": {"type": "literal", "value": 20}
+        },
+        {
+          "type": "assign",
+          "target": "sum",
+          "value": {
+            "type": "binary",
+            "op": "+",
+            "left": {"type": "variable", "name": "a"},
+            "right": {"type": "variable", "name": "b"}
+          }
+        },
+        {
+          "type": "return",
+          "value": {"type": "variable", "name": "sum"}
+        }
+      ]
+    }
+  ]
+}
+```
+
+## Control Flow Examples
+
+### Conditional Logic
+
+```json
+{
+  "type": "module",
+  "name": "max_value",
+  "functions": [
+    {
+      "type": "function",
+      "name": "max",
+      "params": [
+        {"name": "a", "type": "int"},
+        {"name": "b", "type": "int"}
+      ],
+      "returns": "int",
+      "body": [
+        {
+          "type": "if",
+          "cond": {
+            "type": "binary",
+            "op": ">",
+            "left": {"type": "variable", "name": "a"},
+            "right": {"type": "variable", "name": "b"}
+          },
+          "then": [
+            {"type": "return", "value": {"type": "variable", "name": "a"}}
+          ],
+          "else": [
+            {"type": "return", "value": {"type": "variable", "name": "b"}}
+          ]
+        }
+      ]
+    }
+  ]
+}
+```
+
+### While Loop - Sum of Numbers
+
+```json
+{
+  "type": "module",
+  "name": "sum_numbers",
+  "functions": [
+    {
+      "type": "function",
+      "name": "sumToN",
+      "params": [{"name": "n", "type": "int"}],
+      "returns": "int",
+      "body": [
+        {
+          "type": "assign",
+          "target": "sum",
+          "value": {"type": "literal", "value": 0}
+        },
+        {
+          "type": "assign",
+          "target": "i",
+          "value": {"type": "literal", "value": 1}
+        },
+        {
+          "type": "while",
+          "cond": {
+            "type": "binary",
+            "op": "<=",
+            "left": {"type": "variable", "name": "i"},
+            "right": {"type": "variable", "name": "n"}
+          },
+          "body": [
+            {
+              "type": "assign",
+              "target": "sum",
+              "value": {
+                "type": "binary",
+                "op": "+",
+                "left": {"type": "variable", "name": "sum"},
+                "right": {"type": "variable", "name": "i"}
+              }
+            },
+            {
+              "type": "assign",
+              "target": "i",
+              "value": {
+                "type": "binary",
+                "op": "+",
+                "left": {"type": "variable", "name": "i"},
+                "right": {"type": "literal", "value": 1}
+              }
+            }
+          ]
+        },
+        {
+          "type": "return",
+          "value": {"type": "variable", "name": "sum"}
+        }
+      ]
+    }
+  ]
+}
+```
+
+### For Loop - Array Sum
+
+```json
+{
+  "type": "module",
+  "name": "array_sum",
+  "functions": [
+    {
+      "type": "function",
+      "name": "main",
+      "params": [],
+      "returns": "int",
+      "body": [
+        {
+          "type": "assign",
+          "target": "numbers",
+          "value": {
+            "type": "array_literal",
+            "elements": [
+              {"type": "literal", "value": 1},
+              {"type": "literal", "value": 2},
+              {"type": "literal", "value": 3},
+              {"type": "literal", "value": 4},
+              {"type": "literal", "value": 5}
+            ]
+          }
+        },
+        {
+          "type": "assign",
+          "target": "sum",
+          "value": {"type": "literal", "value": 0}
+        },
+        {
+          "type": "assign",
+          "target": "i",
+          "value": {"type": "literal", "value": 0}
+        },
+        {
+          "type": "for",
+          "cond": {
+            "type": "binary",
+            "op": "<",
+            "left": {"type": "variable", "name": "i"},
+            "right": {"type": "literal", "value": 5}
+          },
+          "body": [
+            {
+              "type": "assign",
+              "target": "sum",
+              "value": {
+                "type": "binary",
+                "op": "+",
+                "left": {"type": "variable", "name": "sum"},
+                "right": {
+                  "type": "index",
+                  "object": {"type": "variable", "name": "numbers"},
+                  "index": {"type": "variable", "name": "i"}
+                }
+              }
+            },
+            {
+              "type": "assign",
+              "target": "i",
+              "value": {
+                "type": "binary",
+                "op": "+",
+                "left": {"type": "variable", "name": "i"},
+                "right": {"type": "literal", "value": 1}
+              }
+            }
+          ]
+        },
+        {
+          "type": "return",
+          "value": {"type": "variable", "name": "sum"}
+        }
+      ]
+    }
+  ]
+}
+```
+
+## Recursive Functions
+
+### Fibonacci Sequence
+
+```json
+{
+  "type": "module",
+  "name": "fibonacci",
+  "functions": [
+    {
+      "type": "function",
+      "name": "fib",
+      "params": [{"name": "n", "type": "int"}],
+      "returns": "int",
+      "body": [
+        {
+          "type": "if",
+          "cond": {
+            "type": "binary",
+            "op": "<=",
+            "left": {"type": "variable", "name": "n"},
+            "right": {"type": "literal", "value": 1}
+          },
+          "then": [
+            {"type": "return", "value": {"type": "variable", "name": "n"}}
+          ],
+          "else": [
+            {
+              "type": "return",
+              "value": {
+                "type": "binary",
+                "op": "+",
+                "left": {
+                  "type": "call",
+                  "name": "fib",
+                  "args": [{
+                    "type": "binary",
+                    "op": "-",
+                    "left": {"type": "variable", "name": "n"},
+                    "right": {"type": "literal", "value": 1}
+                  }]
+                },
+                "right": {
+                  "type": "call",
+                  "name": "fib",
+                  "args": [{
+                    "type": "binary",
+                    "op": "-",
+                    "left": {"type": "variable", "name": "n"},
+                    "right": {"type": "literal", "value": 2}
+                  }]
+                }
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+```
+
+### Factorial
+
+```json
+{
+  "type": "module",
+  "name": "factorial",
+  "functions": [
+    {
+      "type": "function",
+      "name": "factorial",
+      "params": [{"name": "n", "type": "int"}],
+      "returns": "int",
+      "body": [
+        {
+          "type": "if",
+          "cond": {
+            "type": "binary",
+            "op": "<=",
+            "left": {"type": "variable", "name": "n"},
+            "right": {"type": "literal", "value": 1}
+          },
+          "then": [
+            {"type": "return", "value": {"type": "literal", "value": 1}}
+          ],
+          "else": [
+            {
+              "type": "return",
+              "value": {
+                "type": "binary",
+                "op": "*",
+                "left": {"type": "variable", "name": "n"},
+                "right": {
+                  "type": "call",
+                  "name": "factorial",
+                  "args": [{
+                    "type": "binary",
+                    "op": "-",
+                    "left": {"type": "variable", "name": "n"},
+                    "right": {"type": "literal", "value": 1}
+                  }]
+                }
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+```
+
+## Data Structures
+
+### Working with Arrays
+
+```json
+{
+  "type": "module",
+  "name": "array_operations",
+  "functions": [
+    {
+      "type": "function",
+      "name": "reverseArray",
+      "params": [{"name": "arr", "type": "array"}],
+      "returns": "array",
+      "body": [
+        {
+          "type": "assign",
+          "target": "length",
+          "value": {
+            "type": "builtin",
+            "name": "collections.length",
+            "args": [{"type": "variable", "name": "arr"}]
+          }
+        },
+        {
+          "type": "assign",
+          "target": "reversed",
+          "value": {"type": "array_literal", "elements": []}
+        },
+        {
+          "type": "assign",
+          "target": "i",
+          "value": {
+            "type": "binary",
+            "op": "-",
+            "left": {"type": "variable", "name": "length"},
+            "right": {"type": "literal", "value": 1}
+          }
+        },
+        {
+          "type": "while",
+          "cond": {
+            "type": "binary",
+            "op": ">=",
+            "left": {"type": "variable", "name": "i"},
+            "right": {"type": "literal", "value": 0}
+          },
+          "body": [
+            {
+              "type": "expr",
+              "value": {
+                "type": "builtin",
+                "name": "collections.append",
+                "args": [
+                  {"type": "variable", "name": "reversed"},
+                  {
+                    "type": "index",
+                    "object": {"type": "variable", "name": "arr"},
+                    "index": {"type": "variable", "name": "i"}
+                  }
+                ]
+              }
+            },
+            {
+              "type": "assign",
+              "target": "i",
+              "value": {
+                "type": "binary",
+                "op": "-",
+                "left": {"type": "variable", "name": "i"},
+                "right": {"type": "literal", "value": 1}
+              }
+            }
+          ]
+        },
+        {
+          "type": "return",
+          "value": {"type": "variable", "name": "reversed"}
+        }
+      ]
+    }
+  ]
+}
+```
+
+### Working with Maps
+
+```json
+{
+  "type": "module",
+  "name": "map_example",
+  "functions": [
+    {
+      "type": "function",
+      "name": "main",
+      "params": [],
+      "returns": "void",
+      "body": [
+        {
+          "type": "assign",
+          "target": "person",
+          "value": {
+            "type": "map_literal",
+            "pairs": [
+              {
+                "key": {"type": "literal", "value": "name"},
+                "value": {"type": "literal", "value": "Alice"}
+              },
+              {
+                "key": {"type": "literal", "value": "age"},
+                "value": {"type": "literal", "value": 30}
+              },
+              {
+                "key": {"type": "literal", "value": "city"},
+                "value": {"type": "literal", "value": "New York"}
+              }
+            ]
+          }
+        },
+        {
+          "type": "assign",
+          "target": "name",
+          "value": {
+            "type": "index",
+            "object": {"type": "variable", "name": "person"},
+            "index": {"type": "literal", "value": "name"}
+          }
+        },
+        {
+          "type": "expr",
+          "value": {
+            "type": "builtin",
+            "name": "io.print",
+            "args": [{"type": "variable", "name": "name"}]
+          }
+        }
+      ]
+    }
+  ]
+}
+```
+
+## Standard Library Usage
+
+### Math Operations
+
+```json
+{
+  "type": "module",
+  "name": "math_demo",
+  "functions": [
+    {
+      "type": "function",
+      "name": "calculateHypotenuse",
+      "params": [
+        {"name": "a", "type": "float"},
+        {"name": "b", "type": "float"}
+      ],
+      "returns": "float",
+      "body": [
+        {
+          "type": "assign",
+          "target": "a_squared",
+          "value": {
+            "type": "builtin",
+            "name": "math.pow",
+            "args": [
+              {"type": "variable", "name": "a"},
+              {"type": "literal", "value": 2}
+            ]
+          }
+        },
+        {
+          "type": "assign",
+          "target": "b_squared",
+          "value": {
+            "type": "builtin",
+            "name": "math.pow",
+            "args": [
+              {"type": "variable", "name": "b"},
+              {"type": "literal", "value": 2}
+            ]
+          }
+        },
+        {
+          "type": "assign",
+          "target": "sum",
+          "value": {
+            "type": "binary",
+            "op": "+",
+            "left": {"type": "variable", "name": "a_squared"},
+            "right": {"type": "variable", "name": "b_squared"}
+          }
+        },
+        {
+          "type": "return",
+          "value": {
+            "type": "builtin",
+            "name": "math.sqrt",
+            "args": [{"type": "variable", "name": "sum"}]
+          }
+        }
+      ]
+    }
+  ]
+}
+```
+
+### String Manipulation
+
+```json
+{
+  "type": "module",
+  "name": "string_demo",
+  "functions": [
+    {
+      "type": "function",
+      "name": "formatName",
+      "params": [
+        {"name": "first", "type": "string"},
+        {"name": "last", "type": "string"}
+      ],
+      "returns": "string",
+      "body": [
+        {
+          "type": "assign",
+          "target": "firstUpper",
+          "value": {
+            "type": "builtin",
+            "name": "string.toUpper",
+            "args": [{"type": "variable", "name": "first"}]
+          }
+        },
+        {
+          "type": "assign",
+          "target": "lastUpper",
+          "value": {
+            "type": "builtin",
+            "name": "string.toUpper",
+            "args": [{"type": "variable", "name": "last"}]
+          }
+        },
+        {
+          "type": "assign",
+          "target": "space",
+          "value": {"type": "literal", "value": " "}
+        },
+        {
+          "type": "assign",
+          "target": "fullName",
+          "value": {
+            "type": "builtin",
+            "name": "string.concat",
+            "args": [
+              {"type": "variable", "name": "firstUpper"},
+              {"type": "variable", "name": "space"}
+            ]
+          }
+        },
+        {
+          "type": "return",
+          "value": {
+            "type": "builtin",
+            "name": "string.concat",
+            "args": [
+              {"type": "variable", "name": "fullName"},
+              {"type": "variable", "name": "lastUpper"}
+            ]
+          }
+        }
+      ]
+    }
+  ]
+}
+```
+
+## Module System
+
+### Multi-Module Program
+
+**math_utils.alas.json:**
+```json
+{
+  "type": "module",
+  "name": "math_utils",
+  "exports": ["square", "cube"],
+  "functions": [
+    {
+      "type": "function",
+      "name": "square",
+      "params": [{"name": "x", "type": "int"}],
+      "returns": "int",
+      "body": [
+        {
+          "type": "return",
+          "value": {
+            "type": "binary",
+            "op": "*",
+            "left": {"type": "variable", "name": "x"},
+            "right": {"type": "variable", "name": "x"}
+          }
+        }
+      ]
+    },
+    {
+      "type": "function",
+      "name": "cube",
+      "params": [{"name": "x", "type": "int"}],
+      "returns": "int",
+      "body": [
+        {
+          "type": "return",
+          "value": {
+            "type": "binary",
+            "op": "*",
+            "left": {
+              "type": "call",
+              "name": "square",
+              "args": [{"type": "variable", "name": "x"}]
+            },
+            "right": {"type": "variable", "name": "x"}
+          }
+        }
+      ]
+    }
+  ]
+}
+```
+
+**main.alas.json:**
+```json
+{
+  "type": "module",
+  "name": "main",
+  "imports": ["math_utils"],
+  "functions": [
+    {
+      "type": "function",
+      "name": "main",
+      "params": [],
+      "returns": "void",
+      "body": [
+        {
+          "type": "assign",
+          "target": "result",
+          "value": {
+            "type": "module_call",
+            "module": "math_utils",
+            "name": "cube",
+            "args": [{"type": "literal", "value": 3}]
+          }
+        },
+        {
+          "type": "expr",
+          "value": {
+            "type": "builtin",
+            "name": "io.print",
+            "args": [{"type": "variable", "name": "result"}]
+          }
+        }
+      ]
+    }
+  ]
+}
+```
+
+## Complete Applications
+
+### Prime Number Checker
+
+```json
+{
+  "type": "module",
+  "name": "prime_checker",
+  "functions": [
+    {
+      "type": "function",
+      "name": "isPrime",
+      "params": [{"name": "n", "type": "int"}],
+      "returns": "bool",
+      "body": [
+        {
+          "type": "if",
+          "cond": {
+            "type": "binary",
+            "op": "<=",
+            "left": {"type": "variable", "name": "n"},
+            "right": {"type": "literal", "value": 1}
+          },
+          "then": [
+            {"type": "return", "value": {"type": "literal", "value": false}}
+          ]
+        },
+        {
+          "type": "assign",
+          "target": "i",
+          "value": {"type": "literal", "value": 2}
+        },
+        {
+          "type": "while",
+          "cond": {
+            "type": "binary",
+            "op": "<=",
+            "left": {
+              "type": "binary",
+              "op": "*",
+              "left": {"type": "variable", "name": "i"},
+              "right": {"type": "variable", "name": "i"}
+            },
+            "right": {"type": "variable", "name": "n"}
+          },
+          "body": [
+            {
+              "type": "if",
+              "cond": {
+                "type": "binary",
+                "op": "==",
+                "left": {
+                  "type": "binary",
+                  "op": "%",
+                  "left": {"type": "variable", "name": "n"},
+                  "right": {"type": "variable", "name": "i"}
+                },
+                "right": {"type": "literal", "value": 0}
+              },
+              "then": [
+                {"type": "return", "value": {"type": "literal", "value": false}}
+              ]
+            },
+            {
+              "type": "assign",
+              "target": "i",
+              "value": {
+                "type": "binary",
+                "op": "+",
+                "left": {"type": "variable", "name": "i"},
+                "right": {"type": "literal", "value": 1}
+              }
+            }
+          ]
+        },
+        {
+          "type": "return",
+          "value": {"type": "literal", "value": true}
+        }
+      ]
+    },
+    {
+      "type": "function",
+      "name": "main",
+      "params": [],
+      "returns": "void",
+      "body": [
+        {
+          "type": "assign",
+          "target": "num",
+          "value": {"type": "literal", "value": 17}
+        },
+        {
+          "type": "if",
+          "cond": {
+            "type": "call",
+            "name": "isPrime",
+            "args": [{"type": "variable", "name": "num"}]
+          },
+          "then": [
+            {
+              "type": "expr",
+              "value": {
+                "type": "builtin",
+                "name": "io.print",
+                "args": [{"type": "literal", "value": "Is prime!"}]
+              }
+            }
+          ],
+          "else": [
+            {
+              "type": "expr",
+              "value": {
+                "type": "builtin",
+                "name": "io.print",
+                "args": [{"type": "literal", "value": "Not prime"}]
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+```
+
+## Tips for Writing ALaS Programs
+
+1. **Start Simple**: Begin with basic functions and gradually add complexity
+2. **Use Descriptive Names**: Make your variable and function names meaningful
+3. **Modularize**: Break complex logic into smaller functions
+4. **Test Incrementally**: Validate and run your program as you build it
+5. **Leverage the Standard Library**: Use built-in functions when possible
+6. **Comment Your Intent**: Use the metadata fields to document complex logic

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,321 @@
+# Getting Started with ALaS
+
+This guide will help you write your first ALaS programs and understand the basics of the language.
+
+## Installation
+
+### Prerequisites
+- Go 1.21 or higher
+- LLVM 14+ (optional, for native compilation)
+
+### Building from Source
+
+```bash
+git clone https://github.com/dshills/alas.git
+cd alas
+make build
+```
+
+This creates the following binaries in the `bin/` directory:
+- `alas-validate` - Validates ALaS programs
+- `alas-run` - Interprets ALaS programs
+- `alas-compile` - Compiles ALaS to LLVM IR
+
+## Your First Program
+
+Create a file named `hello.alas.json`:
+
+```json
+{
+  "type": "module",
+  "name": "hello",
+  "functions": [
+    {
+      "type": "function",
+      "name": "main",
+      "params": [],
+      "returns": "void",
+      "body": [
+        {
+          "type": "expr",
+          "value": {
+            "type": "builtin",
+            "name": "io.print",
+            "args": [
+              {"type": "literal", "value": "Hello, ALaS!"}
+            ]
+          }
+        }
+      ]
+    }
+  ]
+}
+```
+
+### Running Your Program
+
+1. **Validate the syntax:**
+   ```bash
+   ./bin/alas-validate -file hello.alas.json
+   ```
+
+2. **Run with the interpreter:**
+   ```bash
+   ./bin/alas-run -file hello.alas.json
+   ```
+
+3. **Compile to LLVM IR:**
+   ```bash
+   ./bin/alas-compile -file hello.alas.json -o hello.ll
+   ```
+
+## Basic Concepts
+
+### Variables and Types
+
+ALaS is strongly typed. Here's how to work with variables:
+
+```json
+{
+  "type": "function",
+  "name": "variables_demo",
+  "params": [],
+  "returns": "int",
+  "body": [
+    {
+      "type": "assign",
+      "target": "x",
+      "value": {"type": "literal", "value": 42}
+    },
+    {
+      "type": "assign",
+      "target": "message",
+      "value": {"type": "literal", "value": "Hello"}
+    },
+    {
+      "type": "assign",
+      "target": "pi",
+      "value": {"type": "literal", "value": 3.14159}
+    },
+    {
+      "type": "return",
+      "value": {"type": "variable", "name": "x"}
+    }
+  ]
+}
+```
+
+### Control Flow
+
+#### If Statements
+
+```json
+{
+  "type": "if",
+  "cond": {
+    "type": "binary",
+    "op": ">",
+    "left": {"type": "variable", "name": "x"},
+    "right": {"type": "literal", "value": 0}
+  },
+  "then": [
+    {
+      "type": "expr",
+      "value": {
+        "type": "builtin",
+        "name": "io.print",
+        "args": [{"type": "literal", "value": "Positive"}]
+      }
+    }
+  ],
+  "else": [
+    {
+      "type": "expr",
+      "value": {
+        "type": "builtin",
+        "name": "io.print",
+        "args": [{"type": "literal", "value": "Non-positive"}]
+      }
+    }
+  ]
+}
+```
+
+#### Loops
+
+While loop example:
+```json
+{
+  "type": "while",
+  "cond": {
+    "type": "binary",
+    "op": "<",
+    "left": {"type": "variable", "name": "i"},
+    "right": {"type": "literal", "value": 10}
+  },
+  "body": [
+    {
+      "type": "assign",
+      "target": "i",
+      "value": {
+        "type": "binary",
+        "op": "+",
+        "left": {"type": "variable", "name": "i"},
+        "right": {"type": "literal", "value": 1}
+      }
+    }
+  ]
+}
+```
+
+### Functions
+
+Define reusable functions:
+
+```json
+{
+  "type": "function",
+  "name": "add",
+  "params": [
+    {"name": "a", "type": "int"},
+    {"name": "b", "type": "int"}
+  ],
+  "returns": "int",
+  "body": [
+    {
+      "type": "return",
+      "value": {
+        "type": "binary",
+        "op": "+",
+        "left": {"type": "variable", "name": "a"},
+        "right": {"type": "variable", "name": "b"}
+      }
+    }
+  ]
+}
+```
+
+Call functions:
+```json
+{
+  "type": "call",
+  "name": "add",
+  "args": [
+    {"type": "literal", "value": 5},
+    {"type": "literal", "value": 3}
+  ]
+}
+```
+
+### Arrays
+
+Create and use arrays:
+
+```json
+{
+  "type": "assign",
+  "target": "numbers",
+  "value": {
+    "type": "array_literal",
+    "elements": [
+      {"type": "literal", "value": 1},
+      {"type": "literal", "value": 2},
+      {"type": "literal", "value": 3}
+    ]
+  }
+}
+```
+
+Access array elements:
+```json
+{
+  "type": "index",
+  "object": {"type": "variable", "name": "numbers"},
+  "index": {"type": "literal", "value": 0}
+}
+```
+
+## Complete Example: Factorial
+
+Here's a complete program that calculates factorials:
+
+```json
+{
+  "type": "module",
+  "name": "factorial_demo",
+  "functions": [
+    {
+      "type": "function",
+      "name": "factorial",
+      "params": [{"name": "n", "type": "int"}],
+      "returns": "int",
+      "body": [
+        {
+          "type": "if",
+          "cond": {
+            "type": "binary",
+            "op": "<=",
+            "left": {"type": "variable", "name": "n"},
+            "right": {"type": "literal", "value": 1}
+          },
+          "then": [
+            {"type": "return", "value": {"type": "literal", "value": 1}}
+          ],
+          "else": [
+            {
+              "type": "return",
+              "value": {
+                "type": "binary",
+                "op": "*",
+                "left": {"type": "variable", "name": "n"},
+                "right": {
+                  "type": "call",
+                  "name": "factorial",
+                  "args": [{
+                    "type": "binary",
+                    "op": "-",
+                    "left": {"type": "variable", "name": "n"},
+                    "right": {"type": "literal", "value": 1}
+                  }]
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "function",
+      "name": "main",
+      "params": [],
+      "returns": "void",
+      "body": [
+        {
+          "type": "assign",
+          "target": "result",
+          "value": {
+            "type": "call",
+            "name": "factorial",
+            "args": [{"type": "literal", "value": 5}]
+          }
+        },
+        {
+          "type": "expr",
+          "value": {
+            "type": "builtin",
+            "name": "io.print",
+            "args": [{"type": "variable", "name": "result"}]
+          }
+        }
+      ]
+    }
+  ]
+}
+```
+
+## Next Steps
+
+- Explore the [Standard Library Reference](stdlib-reference.md) for built-in functions
+- Learn about [modules and code organization](language-spec.md#module-structure)
+- Check out more [examples](examples.md)
+- Read the [LLM Integration Guide](llm-guide.md) for AI-assisted development

--- a/docs/language-spec.md
+++ b/docs/language-spec.md
@@ -1,0 +1,361 @@
+# ALaS Language Specification
+
+## Overview
+
+ALaS (Artificial Language for Autonomous Systems) is a programming language that uses JSON as its primary representation format. This design choice makes it optimized for programmatic generation and manipulation by AI systems rather than human readability.
+
+## Module Structure
+
+Every ALaS program is a module with the following structure:
+
+```json
+{
+  "type": "module",
+  "name": "module_name",
+  "exports": ["function1", "function2"],  // Optional
+  "imports": ["module1", "module2"],       // Optional
+  "functions": [...],                      // Required
+  "types": [...],                          // Optional
+  "meta": {}                               // Optional metadata
+}
+```
+
+## Data Types
+
+### Basic Types
+
+- `int` - 64-bit signed integer
+- `float` - 64-bit floating point
+- `string` - UTF-8 encoded text
+- `bool` - Boolean (true/false)
+- `void` - No value (for functions that don't return)
+
+### Composite Types
+
+- `array` - Ordered collection of elements
+- `map` - Key-value pairs
+
+### Type Examples
+
+```json
+// Integer literal
+{"type": "literal", "value": 42}
+
+// Float literal
+{"type": "literal", "value": 3.14}
+
+// String literal
+{"type": "literal", "value": "Hello, World!"}
+
+// Boolean literal
+{"type": "literal", "value": true}
+
+// Array literal
+{
+  "type": "array_literal",
+  "elements": [
+    {"type": "literal", "value": 1},
+    {"type": "literal", "value": 2},
+    {"type": "literal", "value": 3}
+  ]
+}
+
+// Map literal
+{
+  "type": "map_literal",
+  "pairs": [
+    {
+      "key": {"type": "literal", "value": "name"},
+      "value": {"type": "literal", "value": "Alice"}
+    }
+  ]
+}
+```
+
+## Functions
+
+Functions are the primary building blocks of ALaS programs:
+
+```json
+{
+  "type": "function",
+  "name": "function_name",
+  "params": [
+    {"name": "param1", "type": "int"},
+    {"name": "param2", "type": "string"}
+  ],
+  "returns": "int",
+  "body": [
+    // Statements
+  ]
+}
+```
+
+## Statements
+
+### Assignment Statement
+
+```json
+{
+  "type": "assign",
+  "target": "variable_name",
+  "value": {
+    // Expression
+  }
+}
+```
+
+### If Statement
+
+```json
+{
+  "type": "if",
+  "cond": {
+    // Condition expression
+  },
+  "then": [
+    // Then statements
+  ],
+  "else": [
+    // Else statements (optional)
+  ]
+}
+```
+
+### While Loop
+
+```json
+{
+  "type": "while",
+  "cond": {
+    // Condition expression
+  },
+  "body": [
+    // Loop body statements
+  ]
+}
+```
+
+### For Loop
+
+```json
+{
+  "type": "for",
+  "cond": {
+    // Condition expression
+  },
+  "body": [
+    // Loop body statements
+  ]
+}
+```
+
+### Return Statement
+
+```json
+{
+  "type": "return",
+  "value": {
+    // Return expression (optional)
+  }
+}
+```
+
+### Expression Statement
+
+```json
+{
+  "type": "expr",
+  "value": {
+    // Expression
+  }
+}
+```
+
+## Expressions
+
+### Literals
+
+```json
+{"type": "literal", "value": 42}
+```
+
+### Variables
+
+```json
+{"type": "variable", "name": "var_name"}
+```
+
+### Binary Operations
+
+```json
+{
+  "type": "binary",
+  "op": "+",
+  "left": {"type": "variable", "name": "a"},
+  "right": {"type": "literal", "value": 1}
+}
+```
+
+Supported operators:
+- Arithmetic: `+`, `-`, `*`, `/`, `%`
+- Comparison: `==`, `!=`, `<`, `<=`, `>`, `>=`
+- Logical: `&&`, `||`
+
+### Unary Operations
+
+```json
+{
+  "type": "unary",
+  "op": "!",
+  "operand": {"type": "variable", "name": "flag"}
+}
+```
+
+Supported operators:
+- `!` - Logical NOT
+- `-` - Negation
+
+### Function Calls
+
+```json
+{
+  "type": "call",
+  "name": "function_name",
+  "args": [
+    {"type": "literal", "value": 42}
+  ]
+}
+```
+
+### Module Function Calls
+
+```json
+{
+  "type": "module_call",
+  "module": "math",
+  "name": "sqrt",
+  "args": [
+    {"type": "literal", "value": 16}
+  ]
+}
+```
+
+### Builtin Function Calls
+
+```json
+{
+  "type": "builtin",
+  "name": "io.print",
+  "args": [
+    {"type": "literal", "value": "Hello!"}
+  ]
+}
+```
+
+### Array Indexing
+
+```json
+{
+  "type": "index",
+  "object": {"type": "variable", "name": "array"},
+  "index": {"type": "literal", "value": 0}
+}
+```
+
+### Field Access
+
+```json
+{
+  "type": "field",
+  "object": {"type": "variable", "name": "obj"},
+  "field": "field_name"
+}
+```
+
+## Complete Example
+
+```json
+{
+  "type": "module",
+  "name": "fibonacci",
+  "functions": [
+    {
+      "type": "function",
+      "name": "fib",
+      "params": [{"name": "n", "type": "int"}],
+      "returns": "int",
+      "body": [
+        {
+          "type": "if",
+          "cond": {
+            "type": "binary",
+            "op": "<=",
+            "left": {"type": "variable", "name": "n"},
+            "right": {"type": "literal", "value": 1}
+          },
+          "then": [
+            {
+              "type": "return",
+              "value": {"type": "variable", "name": "n"}
+            }
+          ],
+          "else": [
+            {
+              "type": "return",
+              "value": {
+                "type": "binary",
+                "op": "+",
+                "left": {
+                  "type": "call",
+                  "name": "fib",
+                  "args": [{
+                    "type": "binary",
+                    "op": "-",
+                    "left": {"type": "variable", "name": "n"},
+                    "right": {"type": "literal", "value": 1}
+                  }]
+                },
+                "right": {
+                  "type": "call",
+                  "name": "fib",
+                  "args": [{
+                    "type": "binary",
+                    "op": "-",
+                    "left": {"type": "variable", "name": "n"},
+                    "right": {"type": "literal", "value": 2}
+                  }]
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "function",
+      "name": "main",
+      "params": [],
+      "returns": "int",
+      "body": [
+        {
+          "type": "return",
+          "value": {
+            "type": "call",
+            "name": "fib",
+            "args": [{"type": "literal", "value": 10}]
+          }
+        }
+      ]
+    }
+  ]
+}
+```
+
+## Design Principles
+
+1. **Machine-First**: Every construct is designed for easy generation and parsing by machines
+2. **Explicit**: No implicit conversions or hidden behavior
+3. **Structured**: Consistent JSON schema throughout
+4. **Deterministic**: Same input always produces same output
+5. **Extensible**: Plugin system allows language extensions

--- a/docs/llm-guide.md
+++ b/docs/llm-guide.md
@@ -1,0 +1,396 @@
+# ALaS LLM Integration Guide
+
+This guide provides best practices for using AI/LLM systems to generate ALaS code effectively.
+
+## Overview
+
+ALaS is specifically designed for machine generation. Its JSON-based syntax and explicit structure make it ideal for LLMs to generate correct, working code consistently.
+
+## Key Advantages for LLM Generation
+
+1. **Structured Format**: JSON syntax eliminates parsing ambiguities
+2. **Explicit Types**: No type inference reduces generation errors
+3. **No Implicit Behavior**: Every operation is explicitly defined
+4. **Consistent Schema**: Predictable structure across all constructs
+5. **Machine-Readable Errors**: Error messages designed for AI interpretation
+
+## Prompting Strategies
+
+### Basic Program Generation
+
+**Effective Prompt:**
+```
+Generate an ALaS program that calculates the factorial of a number.
+The program should:
+- Have a recursive factorial function
+- Have a main function that calls factorial(5)
+- Print the result
+```
+
+**LLM Response Pattern:**
+The LLM should generate a complete module with proper JSON structure, including all required fields.
+
+### Specific Function Generation
+
+**Effective Prompt:**
+```
+Create an ALaS function that:
+- Name: "isPalindrome"
+- Parameter: string called "str"
+- Returns: bool
+- Logic: Check if the string reads the same forwards and backwards
+```
+
+### Complex Program Generation
+
+**Effective Prompt:**
+```
+Generate an ALaS program with multiple functions that:
+1. Implements bubble sort for an array of integers
+2. Has a helper function to swap two elements
+3. Has a main function that sorts [5, 2, 8, 1, 9] and prints each step
+```
+
+## Common Patterns for LLMs
+
+### Function Template
+
+When generating functions, LLMs should follow this pattern:
+
+```json
+{
+  "type": "function",
+  "name": "<function_name>",
+  "params": [
+    {"name": "<param1>", "type": "<type1>"},
+    {"name": "<param2>", "type": "<type2>"}
+  ],
+  "returns": "<return_type>",
+  "body": [
+    // Statements
+  ]
+}
+```
+
+### Expression Building
+
+For complex expressions, build them hierarchically:
+
+```json
+// Instead of trying to generate: a + b * c - d
+// Build it as: (a + (b * c)) - d
+{
+  "type": "binary",
+  "op": "-",
+  "left": {
+    "type": "binary",
+    "op": "+",
+    "left": {"type": "variable", "name": "a"},
+    "right": {
+      "type": "binary",
+      "op": "*",
+      "left": {"type": "variable", "name": "b"},
+      "right": {"type": "variable", "name": "c"}
+    }
+  },
+  "right": {"type": "variable", "name": "d"}
+}
+```
+
+### Control Flow Generation
+
+For if-else statements:
+```json
+{
+  "type": "if",
+  "cond": {/* condition expression */},
+  "then": [/* list of statements */],
+  "else": [/* list of statements */]  // Optional
+}
+```
+
+## Best Practices for LLM Generation
+
+### 1. Start with Structure
+
+Always begin with the module structure:
+```json
+{
+  "type": "module",
+  "name": "module_name",
+  "functions": []
+}
+```
+
+### 2. Generate Functions Incrementally
+
+Build functions one at a time:
+- First, generate the function signature
+- Then, add the body statements
+- Finally, verify all variable references
+
+### 3. Use Consistent Naming
+
+- Variables: camelCase (e.g., `userName`, `totalCount`)
+- Functions: camelCase (e.g., `calculateSum`, `isPrime`)
+- Modules: snake_case (e.g., `math_utils`, `string_helpers`)
+
+### 4. Type Safety
+
+Always specify types explicitly:
+- Function parameters must have types
+- Function returns must have types
+- No implicit conversions
+
+### 5. Handle Edge Cases
+
+Generate proper error handling:
+```json
+{
+  "type": "if",
+  "cond": {
+    "type": "binary",
+    "op": "<",
+    "left": {"type": "variable", "name": "index"},
+    "right": {"type": "literal", "value": 0}
+  },
+  "then": [
+    {"type": "return", "value": {"type": "literal", "value": -1}}
+  ]
+}
+```
+
+## Common LLM Generation Errors
+
+### 1. Missing Required Fields
+
+**Wrong:**
+```json
+{
+  "type": "function",
+  "name": "test"
+  // Missing params, returns, body
+}
+```
+
+**Correct:**
+```json
+{
+  "type": "function",
+  "name": "test",
+  "params": [],
+  "returns": "void",
+  "body": []
+}
+```
+
+### 2. Incorrect Type References
+
+**Wrong:**
+```json
+{"type": "variable", "value": "x"}  // Variables don't have 'value'
+```
+
+**Correct:**
+```json
+{"type": "variable", "name": "x"}
+```
+
+### 3. Invalid Statement Nesting
+
+**Wrong:**
+```json
+{
+  "type": "assign",
+  "target": "x",
+  "value": {
+    "type": "if",  // If is a statement, not expression
+    // ...
+  }
+}
+```
+
+**Correct:**
+Use a function call or restructure the logic.
+
+## Advanced Generation Techniques
+
+### 1. Template-Based Generation
+
+Create templates for common patterns:
+
+**Array Processing Template:**
+```json
+{
+  "type": "function",
+  "name": "processArray",
+  "params": [{"name": "arr", "type": "array"}],
+  "returns": "void",
+  "body": [
+    {
+      "type": "assign",
+      "target": "i",
+      "value": {"type": "literal", "value": 0}
+    },
+    {
+      "type": "while",
+      "cond": {
+        "type": "binary",
+        "op": "<",
+        "left": {"type": "variable", "name": "i"},
+        "right": {
+          "type": "builtin",
+          "name": "collections.length",
+          "args": [{"type": "variable", "name": "arr"}]
+        }
+      },
+      "body": [
+        // Process element at index i
+        {
+          "type": "assign",
+          "target": "i",
+          "value": {
+            "type": "binary",
+            "op": "+",
+            "left": {"type": "variable", "name": "i"},
+            "right": {"type": "literal", "value": 1}
+          }
+        }
+      ]
+    }
+  ]
+}
+```
+
+### 2. Modular Generation
+
+Generate modules separately and combine:
+
+1. Generate utility functions
+2. Generate main logic
+3. Generate test functions
+4. Combine into final module
+
+### 3. Iterative Refinement
+
+1. Generate basic structure
+2. Add type information
+3. Implement function bodies
+4. Add error handling
+5. Optimize generated code
+
+## Validation and Testing
+
+### 1. Use the Validator
+
+Always validate generated code:
+```bash
+./bin/alas-validate -file generated.alas.json
+```
+
+### 2. Test Incrementally
+
+1. Generate and test individual functions
+2. Combine into larger programs
+3. Test edge cases
+
+### 3. Common Validation Errors
+
+- **Undefined variables**: Ensure all variables are assigned before use
+- **Type mismatches**: Verify operation compatibility
+- **Missing returns**: All code paths must return if function has return type
+
+## Performance Considerations
+
+### 1. Minimize Nesting
+
+Deep nesting makes generation harder:
+```json
+// Prefer flat structure where possible
+{
+  "type": "assign",
+  "target": "temp1",
+  "value": {/* expression 1 */}
+},
+{
+  "type": "assign",
+  "target": "result",
+  "value": {/* use temp1 */}
+}
+```
+
+### 2. Use Standard Library
+
+Leverage built-in functions instead of reimplementing:
+```json
+// Use math.max instead of custom max function
+{
+  "type": "builtin",
+  "name": "math.max",
+  "args": [
+    {"type": "variable", "name": "a"},
+    {"type": "variable", "name": "b"}
+  ]
+}
+```
+
+## Integration Examples
+
+### ChatGPT/Claude Prompt
+
+```
+You are an ALaS code generator. ALaS uses JSON syntax where:
+- Every program is a module with functions
+- All types are explicit
+- Expressions and statements are separate
+
+Generate an ALaS program that implements quicksort for an integer array.
+```
+
+### GitHub Copilot Integration
+
+Use comments to guide generation:
+```json
+{
+  "type": "module",
+  "name": "quicksort",
+  "functions": [
+    // TODO: Generate partition function that takes array, low, high
+    // TODO: Generate quicksort function that recursively sorts
+    // TODO: Generate main function that tests with [3, 1, 4, 1, 5, 9]
+  ]
+}
+```
+
+## Debugging LLM-Generated Code
+
+### 1. Syntax Errors
+
+- Validate JSON structure first
+- Check for missing commas, brackets
+- Ensure proper quoting
+
+### 2. Semantic Errors
+
+- Trace variable definitions
+- Verify type consistency
+- Check function signatures
+
+### 3. Logic Errors
+
+- Add print statements for debugging
+- Test with simple inputs first
+- Verify algorithm implementation
+
+## Future Enhancements
+
+As ALaS evolves, LLM integration will improve with:
+
+1. **Semantic Templates**: Higher-level pattern descriptions
+2. **Error Recovery**: Automatic fixing of common mistakes
+3. **Optimization Hints**: Performance-aware generation
+4. **Domain-Specific Libraries**: Specialized generation for different domains
+
+## Conclusion
+
+ALaS is designed to be the ideal target language for AI code generation. By following these guidelines, LLMs can consistently generate correct, efficient ALaS programs. The explicit, structured nature of the language minimizes ambiguity and maximizes the success rate of automated code generation.

--- a/docs/plugin-system.md
+++ b/docs/plugin-system.md
@@ -1,0 +1,384 @@
+# ALaS Plugin System
+
+The ALaS plugin system allows you to extend the language with custom functionality. Plugins can add new functions, types, and capabilities to ALaS programs.
+
+## Overview
+
+Plugins in ALaS are:
+- JSON-based configuration files
+- Loaded at runtime
+- Can provide new builtin functions
+- Support versioning and dependencies
+
+## Plugin Structure
+
+A plugin is defined by a `plugin.json` file:
+
+```json
+{
+  "name": "example-plugin",
+  "version": "1.0.0",
+  "description": "An example ALaS plugin",
+  "author": "Your Name",
+  "license": "MIT",
+  "main": "plugin.alas.json",
+  "exports": {
+    "functions": [
+      {
+        "name": "example.hello",
+        "signature": {
+          "params": [{"name": "name", "type": "string"}],
+          "returns": "string"
+        },
+        "description": "Returns a greeting message"
+      }
+    ]
+  },
+  "dependencies": {
+    "alas": ">=0.1.0"
+  },
+  "metadata": {
+    "homepage": "https://example.com",
+    "repository": "https://github.com/example/plugin"
+  }
+}
+```
+
+## Creating a Plugin
+
+### Step 1: Create Plugin Directory
+
+```bash
+mkdir my-plugin
+cd my-plugin
+```
+
+### Step 2: Create plugin.json
+
+Define your plugin's metadata and exported functions:
+
+```json
+{
+  "name": "math-extra",
+  "version": "1.0.0",
+  "description": "Extended math functions for ALaS",
+  "author": "Your Name",
+  "exports": {
+    "functions": [
+      {
+        "name": "mathx.factorial",
+        "signature": {
+          "params": [{"name": "n", "type": "int"}],
+          "returns": "int"
+        },
+        "description": "Calculates factorial of n"
+      },
+      {
+        "name": "mathx.gcd",
+        "signature": {
+          "params": [
+            {"name": "a", "type": "int"},
+            {"name": "b", "type": "int"}
+          ],
+          "returns": "int"
+        },
+        "description": "Greatest common divisor"
+      }
+    ]
+  }
+}
+```
+
+### Step 3: Implement Plugin Functions
+
+Create `plugin.alas.json` with the implementation:
+
+```json
+{
+  "type": "module",
+  "name": "math_extra_plugin",
+  "exports": ["factorial", "gcd"],
+  "functions": [
+    {
+      "type": "function",
+      "name": "factorial",
+      "params": [{"name": "n", "type": "int"}],
+      "returns": "int",
+      "body": [
+        {
+          "type": "if",
+          "cond": {
+            "type": "binary",
+            "op": "<=",
+            "left": {"type": "variable", "name": "n"},
+            "right": {"type": "literal", "value": 1}
+          },
+          "then": [
+            {"type": "return", "value": {"type": "literal", "value": 1}}
+          ],
+          "else": [
+            {
+              "type": "return",
+              "value": {
+                "type": "binary",
+                "op": "*",
+                "left": {"type": "variable", "name": "n"},
+                "right": {
+                  "type": "call",
+                  "name": "factorial",
+                  "args": [{
+                    "type": "binary",
+                    "op": "-",
+                    "left": {"type": "variable", "name": "n"},
+                    "right": {"type": "literal", "value": 1}
+                  }]
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "function",
+      "name": "gcd",
+      "params": [
+        {"name": "a", "type": "int"},
+        {"name": "b", "type": "int"}
+      ],
+      "returns": "int",
+      "body": [
+        {
+          "type": "if",
+          "cond": {
+            "type": "binary",
+            "op": "==",
+            "left": {"type": "variable", "name": "b"},
+            "right": {"type": "literal", "value": 0}
+          },
+          "then": [
+            {"type": "return", "value": {"type": "variable", "name": "a"}}
+          ],
+          "else": [
+            {
+              "type": "return",
+              "value": {
+                "type": "call",
+                "name": "gcd",
+                "args": [
+                  {"type": "variable", "name": "b"},
+                  {
+                    "type": "binary",
+                    "op": "%",
+                    "left": {"type": "variable", "name": "a"},
+                    "right": {"type": "variable", "name": "b"}
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+```
+
+## Plugin Management
+
+### Listing Plugins
+
+```bash
+./bin/alas-plugin list -path plugins/
+```
+
+### Validating a Plugin
+
+```bash
+./bin/alas-plugin validate my-plugin/plugin.json
+```
+
+### Creating a New Plugin
+
+```bash
+./bin/alas-plugin create my-new-plugin
+```
+
+## Using Plugins in ALaS Programs
+
+Once a plugin is installed, you can use its functions:
+
+```json
+{
+  "type": "module",
+  "name": "plugin_usage",
+  "imports": ["math-extra"],
+  "functions": [
+    {
+      "type": "function",
+      "name": "main",
+      "params": [],
+      "returns": "void",
+      "body": [
+        {
+          "type": "assign",
+          "target": "result",
+          "value": {
+            "type": "builtin",
+            "name": "mathx.factorial",
+            "args": [{"type": "literal", "value": 5}]
+          }
+        },
+        {
+          "type": "expr",
+          "value": {
+            "type": "builtin",
+            "name": "io.print",
+            "args": [{"type": "variable", "name": "result"}]
+          }
+        }
+      ]
+    }
+  ]
+}
+```
+
+## Advanced Plugin Features
+
+### Plugin Dependencies
+
+Plugins can depend on other plugins:
+
+```json
+{
+  "dependencies": {
+    "alas": ">=0.1.0",
+    "another-plugin": "^1.0.0"
+  }
+}
+```
+
+### Plugin Configuration
+
+Plugins can accept configuration:
+
+```json
+{
+  "config": {
+    "precision": {
+      "type": "int",
+      "default": 10,
+      "description": "Decimal precision for calculations"
+    }
+  }
+}
+```
+
+### Native Extensions
+
+For performance-critical operations, plugins can reference native implementations:
+
+```json
+{
+  "native": {
+    "library": "libmathx.so",
+    "functions": {
+      "mathx.factorial": "mathx_factorial"
+    }
+  }
+}
+```
+
+## Example Plugins
+
+### String Utilities Plugin
+
+```json
+{
+  "name": "string-utils",
+  "version": "1.0.0",
+  "exports": {
+    "functions": [
+      {
+        "name": "strutil.reverse",
+        "signature": {
+          "params": [{"name": "str", "type": "string"}],
+          "returns": "string"
+        }
+      },
+      {
+        "name": "strutil.repeat",
+        "signature": {
+          "params": [
+            {"name": "str", "type": "string"},
+            {"name": "count", "type": "int"}
+          ],
+          "returns": "string"
+        }
+      }
+    ]
+  }
+}
+```
+
+### Date/Time Plugin
+
+```json
+{
+  "name": "datetime",
+  "version": "1.0.0",
+  "exports": {
+    "functions": [
+      {
+        "name": "datetime.now",
+        "signature": {
+          "params": [],
+          "returns": "int"
+        },
+        "description": "Returns current Unix timestamp"
+      },
+      {
+        "name": "datetime.format",
+        "signature": {
+          "params": [
+            {"name": "timestamp", "type": "int"},
+            {"name": "format", "type": "string"}
+          ],
+          "returns": "string"
+        }
+      }
+    ]
+  }
+}
+```
+
+## Best Practices
+
+1. **Namespace Functions**: Use a unique prefix for your plugin functions (e.g., `myplugin.function`)
+2. **Version Carefully**: Follow semantic versioning for your plugins
+3. **Document Thoroughly**: Provide clear descriptions for all exported functions
+4. **Test Extensively**: Include test cases with your plugin
+5. **Handle Errors**: Ensure your plugin functions handle edge cases gracefully
+
+## Plugin Development Tips
+
+- Start with simple, pure functions
+- Test your plugin with the validator before distribution
+- Consider performance implications for complex operations
+- Provide examples of plugin usage
+- Keep plugin size reasonable - split large plugins into multiple modules
+
+## Distribution
+
+Plugins can be distributed through:
+- Git repositories
+- Package registries
+- Direct file sharing
+- Plugin marketplace (future feature)
+
+## Security Considerations
+
+- Plugins run with the same permissions as the ALaS runtime
+- Always validate and review third-party plugins before use
+- Consider sandboxing for untrusted plugins
+- Check plugin signatures when available

--- a/docs/stdlib-reference.md
+++ b/docs/stdlib-reference.md
@@ -1,0 +1,441 @@
+# ALaS Standard Library Reference
+
+The ALaS standard library provides built-in functions organized into modules. All standard library functions are called using the `builtin` expression type.
+
+## I/O Module (`io`)
+
+### `io.print`
+
+Prints values to standard output.
+
+**Signature:** `void io.print(value)`
+
+**Parameters:**
+- `value`: Any type - The value to print
+
+**Example:**
+```json
+{
+  "type": "builtin",
+  "name": "io.print",
+  "args": [{"type": "literal", "value": "Hello, World!"}]
+}
+```
+
+### `io.println`
+
+Prints values to standard output with a newline.
+
+**Signature:** `void io.println(value)`
+
+**Parameters:**
+- `value`: Any type - The value to print
+
+## Math Module (`math`)
+
+### `math.abs`
+
+Returns the absolute value of a number.
+
+**Signature:** `float math.abs(number)`
+
+**Parameters:**
+- `number`: int or float - The input number
+
+**Returns:** The absolute value
+
+**Example:**
+```json
+{
+  "type": "builtin",
+  "name": "math.abs",
+  "args": [{"type": "literal", "value": -42}]
+}
+```
+
+### `math.sqrt`
+
+Returns the square root of a number.
+
+**Signature:** `float math.sqrt(number)`
+
+**Parameters:**
+- `number`: int or float - The input number (must be non-negative)
+
+**Returns:** The square root
+
+**Example:**
+```json
+{
+  "type": "builtin",
+  "name": "math.sqrt",
+  "args": [{"type": "literal", "value": 16}]
+}
+```
+
+### `math.pow`
+
+Raises a number to a power.
+
+**Signature:** `float math.pow(base, exponent)`
+
+**Parameters:**
+- `base`: int or float - The base number
+- `exponent`: int or float - The exponent
+
+**Returns:** base raised to the power of exponent
+
+### `math.max`
+
+Returns the maximum of two numbers.
+
+**Signature:** `float math.max(a, b)`
+
+**Parameters:**
+- `a`: int or float - First number
+- `b`: int or float - Second number
+
+**Returns:** The larger of the two numbers
+
+### `math.min`
+
+Returns the minimum of two numbers.
+
+**Signature:** `float math.min(a, b)`
+
+**Parameters:**
+- `a`: int or float - First number
+- `b`: int or float - Second number
+
+**Returns:** The smaller of the two numbers
+
+### `math.floor`
+
+Returns the largest integer less than or equal to a number.
+
+**Signature:** `int math.floor(number)`
+
+**Parameters:**
+- `number`: float - The input number
+
+**Returns:** The floor value
+
+### `math.ceil`
+
+Returns the smallest integer greater than or equal to a number.
+
+**Signature:** `int math.ceil(number)`
+
+**Parameters:**
+- `number`: float - The input number
+
+**Returns:** The ceiling value
+
+### `math.round`
+
+Rounds a number to the nearest integer.
+
+**Signature:** `int math.round(number)`
+
+**Parameters:**
+- `number`: float - The input number
+
+**Returns:** The rounded value
+
+## String Module (`string`)
+
+### `string.length`
+
+Returns the length of a string.
+
+**Signature:** `int string.length(str)`
+
+**Parameters:**
+- `str`: string - The input string
+
+**Returns:** The number of characters
+
+**Example:**
+```json
+{
+  "type": "builtin",
+  "name": "string.length",
+  "args": [{"type": "literal", "value": "Hello"}]
+}
+```
+
+### `string.toUpper`
+
+Converts a string to uppercase.
+
+**Signature:** `string string.toUpper(str)`
+
+**Parameters:**
+- `str`: string - The input string
+
+**Returns:** The uppercase string
+
+### `string.toLower`
+
+Converts a string to lowercase.
+
+**Signature:** `string string.toLower(str)`
+
+**Parameters:**
+- `str`: string - The input string
+
+**Returns:** The lowercase string
+
+### `string.concat`
+
+Concatenates two strings.
+
+**Signature:** `string string.concat(str1, str2)`
+
+**Parameters:**
+- `str1`: string - First string
+- `str2`: string - Second string
+
+**Returns:** The concatenated string
+
+### `string.substring`
+
+Extracts a substring.
+
+**Signature:** `string string.substring(str, start, length)`
+
+**Parameters:**
+- `str`: string - The input string
+- `start`: int - Starting position (0-based)
+- `length`: int - Number of characters to extract
+
+**Returns:** The substring
+
+## Collections Module (`collections`)
+
+### `collections.length`
+
+Returns the length of an array or the number of entries in a map.
+
+**Signature:** `int collections.length(collection)`
+
+**Parameters:**
+- `collection`: array or map - The collection to measure
+
+**Returns:** The number of elements
+
+**Example:**
+```json
+{
+  "type": "builtin",
+  "name": "collections.length",
+  "args": [{"type": "variable", "name": "myArray"}]
+}
+```
+
+### `collections.contains`
+
+Checks if a collection contains a value.
+
+**Signature:** `bool collections.contains(collection, value)`
+
+**Parameters:**
+- `collection`: array or string - The collection to search
+- `value`: any - The value to find
+
+**Returns:** true if the value is found, false otherwise
+
+### `collections.append`
+
+Adds an element to the end of an array.
+
+**Signature:** `void collections.append(array, value)`
+
+**Parameters:**
+- `array`: array - The array to modify
+- `value`: any - The value to append
+
+### `collections.remove`
+
+Removes an element from an array at a specific index.
+
+**Signature:** `void collections.remove(array, index)`
+
+**Parameters:**
+- `array`: array - The array to modify
+- `index`: int - The index to remove
+
+## Type Module (`type`)
+
+### `type.typeOf`
+
+Returns a string representation of a value's type.
+
+**Signature:** `string type.typeOf(value)`
+
+**Parameters:**
+- `value`: any - The value to inspect
+
+**Returns:** Type name as string ("int", "float", "string", "bool", "array", "map")
+
+**Example:**
+```json
+{
+  "type": "builtin",
+  "name": "type.typeOf",
+  "args": [{"type": "literal", "value": 42}]
+}
+```
+
+### `type.isInt`
+
+Checks if a value is an integer.
+
+**Signature:** `bool type.isInt(value)`
+
+**Parameters:**
+- `value`: any - The value to check
+
+**Returns:** true if the value is an integer
+
+### `type.isFloat`
+
+Checks if a value is a float.
+
+**Signature:** `bool type.isFloat(value)`
+
+**Parameters:**
+- `value`: any - The value to check
+
+**Returns:** true if the value is a float
+
+### `type.isString`
+
+Checks if a value is a string.
+
+**Signature:** `bool type.isString(value)`
+
+**Parameters:**
+- `value`: any - The value to check
+
+**Returns:** true if the value is a string
+
+### `type.isBool`
+
+Checks if a value is a boolean.
+
+**Signature:** `bool type.isBool(value)`
+
+**Parameters:**
+- `value`: any - The value to check
+
+**Returns:** true if the value is a boolean
+
+### `type.isArray`
+
+Checks if a value is an array.
+
+**Signature:** `bool type.isArray(value)`
+
+**Parameters:**
+- `value`: any - The value to check
+
+**Returns:** true if the value is an array
+
+### `type.isMap`
+
+Checks if a value is a map.
+
+**Signature:** `bool type.isMap(value)`
+
+**Parameters:**
+- `value`: any - The value to check
+
+**Returns:** true if the value is a map
+
+## Complete Example
+
+Here's a program that demonstrates various standard library functions:
+
+```json
+{
+  "type": "module",
+  "name": "stdlib_demo",
+  "functions": [
+    {
+      "type": "function",
+      "name": "main",
+      "params": [],
+      "returns": "void",
+      "body": [
+        {
+          "type": "expr",
+          "value": {
+            "type": "builtin",
+            "name": "io.print",
+            "args": [{"type": "literal", "value": "=== Standard Library Demo ==="}]
+          }
+        },
+        {
+          "type": "assign",
+          "target": "x",
+          "value": {
+            "type": "builtin",
+            "name": "math.sqrt",
+            "args": [{"type": "literal", "value": 16}]
+          }
+        },
+        {
+          "type": "assign",
+          "target": "message",
+          "value": {"type": "literal", "value": "hello world"}
+        },
+        {
+          "type": "assign",
+          "target": "upper",
+          "value": {
+            "type": "builtin",
+            "name": "string.toUpper",
+            "args": [{"type": "variable", "name": "message"}]
+          }
+        },
+        {
+          "type": "assign",
+          "target": "numbers",
+          "value": {
+            "type": "array_literal",
+            "elements": [
+              {"type": "literal", "value": 1},
+              {"type": "literal", "value": 2},
+              {"type": "literal", "value": 3}
+            ]
+          }
+        },
+        {
+          "type": "assign",
+          "target": "len",
+          "value": {
+            "type": "builtin",
+            "name": "collections.length",
+            "args": [{"type": "variable", "name": "numbers"}]
+          }
+        },
+        {
+          "type": "expr",
+          "value": {
+            "type": "builtin",
+            "name": "io.print",
+            "args": [{"type": "variable", "name": "upper"}]
+          }
+        }
+      ]
+    }
+  ]
+}
+```
+
+## Notes
+
+- All standard library functions are pure (no side effects) except for I/O operations
+- Type checking is performed at runtime for dynamic operations
+- Some functions may not be available in all compilation targets

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,424 @@
+# ALaS Troubleshooting Guide
+
+This guide helps you diagnose and fix common issues when working with ALaS.
+
+## Common Errors and Solutions
+
+### Validation Errors
+
+#### "Module must have 'type' field set to 'module'"
+
+**Cause:** Missing or incorrect module type declaration.
+
+**Solution:**
+```json
+{
+  "type": "module",  // This field is required
+  "name": "my_module",
+  "functions": []
+}
+```
+
+#### "Function must have a body"
+
+**Cause:** Function declared without body array.
+
+**Solution:**
+```json
+{
+  "type": "function",
+  "name": "myFunc",
+  "params": [],
+  "returns": "void",
+  "body": []  // Even empty functions need a body array
+}
+```
+
+#### "Undefined variable: x"
+
+**Cause:** Using a variable before it's assigned.
+
+**Solution:**
+```json
+// Wrong
+{
+  "type": "return",
+  "value": {"type": "variable", "name": "x"}
+}
+
+// Correct - assign first
+{
+  "type": "assign",
+  "target": "x",
+  "value": {"type": "literal", "value": 42}
+},
+{
+  "type": "return",
+  "value": {"type": "variable", "name": "x"}
+}
+```
+
+#### "Unknown statement type: for"
+
+**Cause:** Validator doesn't recognize for loops (may need update).
+
+**Solution:** Ensure you're using the latest version of ALaS that supports for loops, or use while loops as a workaround.
+
+### Runtime Errors
+
+#### "Type mismatch in binary operation"
+
+**Cause:** Trying to perform operations on incompatible types.
+
+**Solution:**
+```json
+// Wrong - can't add string and number
+{
+  "type": "binary",
+  "op": "+",
+  "left": {"type": "literal", "value": "hello"},
+  "right": {"type": "literal", "value": 42}
+}
+
+// Correct - same types
+{
+  "type": "binary",
+  "op": "+",
+  "left": {"type": "literal", "value": 10},
+  "right": {"type": "literal", "value": 42}
+}
+```
+
+#### "Division by zero"
+
+**Cause:** Attempting to divide by zero.
+
+**Solution:** Add a check before division:
+```json
+{
+  "type": "if",
+  "cond": {
+    "type": "binary",
+    "op": "!=",
+    "left": {"type": "variable", "name": "divisor"},
+    "right": {"type": "literal", "value": 0}
+  },
+  "then": [
+    {
+      "type": "assign",
+      "target": "result",
+      "value": {
+        "type": "binary",
+        "op": "/",
+        "left": {"type": "variable", "name": "dividend"},
+        "right": {"type": "variable", "name": "divisor"}
+      }
+    }
+  ]
+}
+```
+
+#### "Array index out of bounds"
+
+**Cause:** Accessing array element beyond its size.
+
+**Solution:** Check array bounds:
+```json
+{
+  "type": "if",
+  "cond": {
+    "type": "binary",
+    "op": "<",
+    "left": {"type": "variable", "name": "index"},
+    "right": {
+      "type": "builtin",
+      "name": "collections.length",
+      "args": [{"type": "variable", "name": "array"}]
+    }
+  },
+  "then": [
+    // Safe to access array[index]
+  ]
+}
+```
+
+### Compilation Errors (LLVM)
+
+#### "Failed to generate function: variable is not a pointer type"
+
+**Cause:** LLVM backend issue with variable storage.
+
+**Solution:** This is typically an internal compiler issue. Ensure variables are properly declared and initialized.
+
+#### "Unknown builtin function"
+
+**Cause:** Using a builtin function not recognized by the compiler.
+
+**Solution:** Check the standard library reference for correct function names:
+- Use `io.print` not `print`
+- Use `math.sqrt` not `sqrt`
+- Include the module prefix
+
+### JSON Syntax Errors
+
+#### "Invalid JSON"
+
+**Common Causes:**
+1. Missing commas between elements
+2. Trailing commas
+3. Unclosed brackets or braces
+4. Incorrect string quoting
+
+**Solution:** Use a JSON validator or editor with syntax highlighting.
+
+```json
+// Wrong - missing comma
+{
+  "type": "module"
+  "name": "test"
+}
+
+// Wrong - trailing comma
+{
+  "type": "module",
+  "name": "test",  // <- Remove this comma
+}
+
+// Correct
+{
+  "type": "module",
+  "name": "test"
+}
+```
+
+## Debugging Techniques
+
+### 1. Add Print Statements
+
+Insert print statements to trace execution:
+```json
+{
+  "type": "expr",
+  "value": {
+    "type": "builtin",
+    "name": "io.print",
+    "args": [{"type": "literal", "value": "Debug: reached here"}]
+  }
+}
+```
+
+### 2. Validate Incrementally
+
+Build your program step by step:
+1. Start with minimal structure
+2. Add one function at a time
+3. Validate after each addition
+
+### 3. Check Types
+
+Use type checking builtins:
+```json
+{
+  "type": "assign",
+  "target": "valueType",
+  "value": {
+    "type": "builtin",
+    "name": "type.typeOf",
+    "args": [{"type": "variable", "name": "myVar"}]
+  }
+},
+{
+  "type": "expr",
+  "value": {
+    "type": "builtin",
+    "name": "io.print",
+    "args": [{"type": "variable", "name": "valueType"}]
+  }
+}
+```
+
+### 4. Simplify Complex Expressions
+
+Break down complex expressions:
+```json
+// Instead of one complex expression
+// Break it into steps:
+{
+  "type": "assign",
+  "target": "temp1",
+  "value": {/* first part */}
+},
+{
+  "type": "assign",
+  "target": "temp2",
+  "value": {/* second part */}
+},
+{
+  "type": "assign",
+  "target": "result",
+  "value": {/* combine temp1 and temp2 */}
+}
+```
+
+## Performance Issues
+
+### Slow Recursive Functions
+
+**Problem:** Deep recursion causing stack overflow or slow performance.
+
+**Solution:** Consider iterative approach:
+```json
+// Convert recursive factorial to iterative
+{
+  "type": "function",
+  "name": "factorial_iterative",
+  "params": [{"name": "n", "type": "int"}],
+  "returns": "int",
+  "body": [
+    {
+      "type": "assign",
+      "target": "result",
+      "value": {"type": "literal", "value": 1}
+    },
+    {
+      "type": "assign",
+      "target": "i",
+      "value": {"type": "literal", "value": 2}
+    },
+    {
+      "type": "while",
+      "cond": {
+        "type": "binary",
+        "op": "<=",
+        "left": {"type": "variable", "name": "i"},
+        "right": {"type": "variable", "name": "n"}
+      },
+      "body": [
+        {
+          "type": "assign",
+          "target": "result",
+          "value": {
+            "type": "binary",
+            "op": "*",
+            "left": {"type": "variable", "name": "result"},
+            "right": {"type": "variable", "name": "i"}
+          }
+        },
+        {
+          "type": "assign",
+          "target": "i",
+          "value": {
+            "type": "binary",
+            "op": "+",
+            "left": {"type": "variable", "name": "i"},
+            "right": {"type": "literal", "value": 1}
+          }
+        }
+      ]
+    },
+    {
+      "type": "return",
+      "value": {"type": "variable", "name": "result"}
+    }
+  ]
+}
+```
+
+### Large Array Operations
+
+**Problem:** Operations on large arrays are slow.
+
+**Solution:** 
+- Process arrays in chunks
+- Use appropriate algorithms (e.g., binary search instead of linear search)
+- Consider using maps for lookups
+
+## Tool-Specific Issues
+
+### alas-validate
+
+**"File not found"**
+- Check file path is correct
+- Use absolute paths if relative paths aren't working
+
+### alas-run
+
+**"Function 'main' not found"**
+- Ensure your module has a main function
+- Specify function name with `-fn` flag if using different entry point
+
+### alas-compile
+
+**"LLVM IR generation failed"**
+- Check for unsupported language features
+- Ensure all types are properly defined
+- Try with simpler program to isolate issue
+
+## Getting Help
+
+If you encounter issues not covered here:
+
+1. **Check Examples**: Review the examples directory for working code patterns
+2. **Validate First**: Always run the validator before other tools
+3. **Minimal Reproduction**: Create the smallest program that shows the issue
+4. **Error Messages**: Include complete error messages when seeking help
+5. **Version Info**: Note which version of ALaS you're using
+
+## FAQ
+
+**Q: Can I use relative paths for imports?**
+A: Module imports use module names, not file paths. Ensure modules are in the module search path.
+
+**Q: Why does my array index return wrong values?**
+A: Check that you're using 0-based indexing. Arrays in ALaS start at index 0.
+
+**Q: How do I debug infinite loops?**
+A: Add a counter and print statements inside the loop to track iterations:
+```json
+{
+  "type": "assign",
+  "target": "debug_counter",
+  "value": {"type": "literal", "value": 0}
+},
+{
+  "type": "while",
+  "cond": {/* your condition */},
+  "body": [
+    {
+      "type": "expr",
+      "value": {
+        "type": "builtin",
+        "name": "io.print",
+        "args": [{"type": "variable", "name": "debug_counter"}]
+      }
+    },
+    {
+      "type": "assign",
+      "target": "debug_counter",
+      "value": {
+        "type": "binary",
+        "op": "+",
+        "left": {"type": "variable", "name": "debug_counter"},
+        "right": {"type": "literal", "value": 1}
+      }
+    },
+    // Rest of loop body
+  ]
+}
+```
+
+**Q: Can I mix types in arrays?**
+A: No, ALaS arrays are homogeneous. All elements must be the same type.
+
+**Q: How do I handle errors in ALaS?**
+A: Currently, ALaS doesn't have exception handling. Use return values to indicate errors:
+```json
+// Return -1 for error, positive value for success
+{
+  "type": "if",
+  "cond": {/* error condition */},
+  "then": [
+    {"type": "return", "value": {"type": "literal", "value": -1}}
+  ]
+}
+```


### PR DESCRIPTION
## Summary

This PR adds comprehensive documentation for ALaS, designed specifically to help both developers and LLMs create programs effectively.

## Documentation Added

### Core Documentation
- **docs/README.md** - Documentation overview and navigation
- **docs/language-spec.md** - Complete language specification with JSON syntax
- **docs/getting-started.md** - Quick start guide with installation and first programs
- **docs/stdlib-reference.md** - Complete standard library function reference

### Development Guides
- **docs/plugin-system.md** - Plugin development and management guide
- **docs/examples.md** - Extensive code examples and common patterns
- **docs/troubleshooting.md** - Common errors and debugging techniques

### LLM Integration
- **docs/llm-guide.md** - Comprehensive guide for AI-assisted ALaS development
  - Prompting strategies
  - Common patterns for LLMs
  - Generation best practices
  - Error handling for generated code

## Key Features

1. **Machine-Friendly Format**: All examples use proper JSON syntax
2. **Complete Coverage**: Documents all language features, statements, expressions, and types
3. **Practical Examples**: Real-world code patterns and complete programs
4. **LLM Optimization**: Specific guidance for AI code generation
5. **Error Prevention**: Troubleshooting guide helps avoid common mistakes

## Documentation Structure

The documentation is organized for easy navigation:
- Start with the overview (README.md)
- Learn basics (getting-started.md)
- Reference materials (language-spec.md, stdlib-reference.md)
- Advanced topics (plugin-system.md)
- Practical help (examples.md, troubleshooting.md)
- AI integration (llm-guide.md)

## Impact

This documentation will significantly improve the developer experience and make ALaS more accessible for:
- New users learning the language
- Developers building ALaS programs
- LLMs generating ALaS code
- Plugin developers extending the language

🤖 Generated with [Claude Code](https://claude.ai/code)